### PR TITLE
feat(coffee): add coffee brewing and fatigue system #6

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import pygame
 from src.world import map_initialization, Background, calculate_camera_offset, Cabin
 from src.entities import Player, Npc, EnemyManager
-from src.ui import Inventory, LoreDisplay, CATS_LORE, COLLECTIBLES_LORE
+from src.ui import Inventory, LoreDisplay, CATS_LORE, COLLECTIBLES_LORE, GameOverScreen
 from src.utils import preload_all_assets
 
 # Initialize Pygame
@@ -54,10 +54,19 @@ def init_game():
 # Initialize game
 background, player, inventory, lore_display, cabin, npc, enemy_manager, spawn_point, MAP_WIDTH, MAP_HEIGHT = init_game()
 
+# Game over screen
+game_over_screen = GameOverScreen(SCREEN_WIDTH, SCREEN_HEIGHT)
+
 # Collection state
 collect_cooldown = 0
 f_key_pressed = False
 g_key_pressed = False
+
+# Coffee brewing state
+c_key_pressed = False
+v_key_pressed = False
+is_brewing = False
+brew_timer = 0
 
 # Main game loop
 running = True
@@ -71,6 +80,29 @@ while running:
 
     keys = pygame.key.get_pressed()
 
+    # Handle game over screen
+    if game_over_screen.is_showing:
+        result = game_over_screen.update(keys)
+        if result == "restart":
+            background, player, inventory, lore_display, cabin, npc, enemy_manager, spawn_point, MAP_WIDTH, MAP_HEIGHT = init_game()
+            collect_cooldown = 0
+            f_key_pressed = False
+            g_key_pressed = False
+            c_key_pressed = False
+            v_key_pressed = False
+            is_brewing = False
+            brew_timer = 0
+
+        # Render game in background (frozen)
+        camera_offset = calculate_camera_offset(player, MAP_WIDTH, MAP_HEIGHT, TILE_SIZE, SCREEN_WIDTH, SCREEN_HEIGHT)
+        background.draw(screen, camera_offset, player, cabin, enemy_manager)
+        npc.draw_sprytek(screen, camera_offset)
+        background.draw_leaves(screen, camera_offset)
+        game_over_screen.draw(screen)
+        pygame.display.flip()
+        clock.tick(60)
+        continue
+
     # If lore display is showing, only update that and block other input
     if lore_display.is_showing:
         lore_display.update(keys)
@@ -81,7 +113,7 @@ while running:
         npc.draw_sprytek(screen, camera_offset)
         background.draw_leaves(screen, camera_offset)
         stored_cats = cabin.get_stored_cat_count()
-        inventory.update_inventory(keys, screen, stored_cats)
+        inventory.update_inventory(keys, screen, stored_cats, player.get_fatigue_percent())
         npc.draw_chat_graphics(screen, player, camera_offset)
 
         # Draw lore display on top
@@ -96,12 +128,17 @@ while running:
     npc.update(keys, player)
     enemy_manager.update(clock.get_time(), player.player_rect)
 
-    # Check enemy collision - restart game if hit
+    # Update fatigue
+    player.update_fatigue(clock.get_time())
+
+    # Check if player fell asleep from exhaustion
+    if player.is_exhausted():
+        game_over_screen.show("You fell asleep!")
+        continue
+
+    # Check enemy collision - show game over if hit
     if enemy_manager.check_player_collision(player.player_rect):
-        background, player, inventory, lore_display, cabin, npc, enemy_manager, spawn_point, MAP_WIDTH, MAP_HEIGHT = init_game()
-        collect_cooldown = 0
-        f_key_pressed = False
-        g_key_pressed = False
+        game_over_screen.show("Voice caught you!")
         continue
 
     # Collection cooldown
@@ -157,15 +194,58 @@ while running:
 
     g_key_pressed = keys[pygame.K_g]
 
+    # Coffee machine interaction (inside cabin, near machine)
+    if player_inside_cabin and cabin.is_near_coffee_machine(player.player_rect):
+        if not is_brewing:
+            if not inventory.has_coffee_available():
+                # Can brew coffee
+                inventory.set_coffee_hint(True, "brew")
+                if keys[pygame.K_c] and not c_key_pressed and collect_cooldown == 0:
+                    is_brewing = True
+                    brew_timer = 3000  # 3 seconds in ms
+                    collect_cooldown = 30
+            else:
+                inventory.set_coffee_hint(False)
+        else:
+            # Brewing in progress
+            inventory.set_coffee_hint(False)
+    else:
+        inventory.set_coffee_hint(False)
+
+    # Brewing process
+    if is_brewing:
+        brew_timer -= clock.get_time()
+        if brew_timer <= 0:
+            is_brewing = False
+            inventory.fill_thermos()
+
+    # Drink coffee anywhere (if has coffee)
+    if inventory.has_coffee_available() and not is_brewing:
+        # Show drink hint when not near coffee machine or already has coffee
+        if not (player_inside_cabin and cabin.is_near_coffee_machine(player.player_rect)):
+            inventory.set_coffee_hint(True, "drink")
+        if keys[pygame.K_v] and not v_key_pressed and collect_cooldown == 0:
+            if inventory.drink_coffee():
+                player.drink_coffee()
+                collect_cooldown = 30
+
+    c_key_pressed = keys[pygame.K_c]
+    v_key_pressed = keys[pygame.K_v]
+
     # Calculate camera offset
     camera_offset = calculate_camera_offset(player, MAP_WIDTH, MAP_HEIGHT, TILE_SIZE, SCREEN_WIDTH, SCREEN_HEIGHT)
 
+    # Calculate brew progress for animation
+    brew_progress = 0
+    if is_brewing:
+        brew_progress = 1.0 - (brew_timer / 3000)  # 0 to 1 as brewing completes
+
     # Render
-    background.draw(screen, camera_offset, player, cabin, enemy_manager)
+    background.draw(screen, camera_offset, player, cabin, enemy_manager, is_brewing, brew_progress)
     npc.draw_sprytek(screen, camera_offset)
     background.draw_leaves(screen, camera_offset)
     stored_cats = cabin.get_stored_cat_count()
-    inventory.update_inventory(keys, screen, stored_cats)
+    inventory.update_inventory(keys, screen, stored_cats, player.get_fatigue_percent())
     npc.draw_chat_graphics(screen, player, camera_offset)
 
     # Update display

--- a/src/entities/player.py
+++ b/src/entities/player.py
@@ -25,9 +25,14 @@ class Player:
         self.animation_speed = 200
 
         # Movement state
-        self.speed = 5
+        self.base_speed = 5
+        self.speed = self.base_speed
         self.is_walking = False
         self.facing_right = True
+
+        # Fatigue system
+        self.fatigue = 100.0  # 0-100 scale (100 = fully awake)
+        self.fatigue_decay = 0.0093  # per frame (~3 min to empty at 60fps)
 
         # Position
         if spawn_position:
@@ -104,3 +109,30 @@ class Player:
         screen_pos = (self.player_rect.x - camera_offset[0],
                       self.player_rect.y - camera_offset[1])
         screen.blit(self.image, screen_pos)
+
+    def update_fatigue(self, dt):
+        """Update fatigue level (decreases over time)."""
+        self.fatigue -= self.fatigue_decay
+        if self.fatigue < 0:
+            self.fatigue = 0
+
+        # Update speed based on fatigue
+        if self.fatigue < 30:
+            # Linear slowdown from 100% to 40% speed as fatigue goes 30 -> 0
+            fatigue_factor = max(0.4, self.fatigue / 30)
+            self.speed = self.base_speed * fatigue_factor
+        else:
+            self.speed = self.base_speed
+
+    def drink_coffee(self):
+        """Restore fatigue to full."""
+        self.fatigue = 100.0
+        self.speed = self.base_speed
+
+    def get_fatigue_percent(self):
+        """Get current fatigue as percentage (0-100)."""
+        return self.fatigue
+
+    def is_exhausted(self):
+        """Check if player is completely exhausted."""
+        return self.fatigue <= 0

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -1,3 +1,4 @@
 from src.ui.inventory import Inventory
 from src.ui.lore_display import LoreDisplay, create_placeholder
 from src.ui.lore_data import CATS_LORE, COLLECTIBLES_LORE
+from src.ui.game_over import GameOverScreen

--- a/src/ui/game_over.py
+++ b/src/ui/game_over.py
@@ -1,0 +1,126 @@
+import pygame
+from src.utils import get_font, get_image
+
+
+class GameOverScreen:
+    """Game over screen with death reason and restart option."""
+
+    def __init__(self, screen_width, screen_height):
+        self.screen_width = screen_width
+        self.screen_height = screen_height
+        self.is_showing = False
+        self.death_reason = ""
+        self.cooldown = 0
+
+        # Fonts
+        self.title_font = get_font(32)
+        self.reason_font = get_font(14)
+        self.hint_font = get_font(10)
+        self.zzz_font = get_font(24)
+
+        # Enemy animation frames
+        self.enemy_frames = []
+        for i in range(1, 5):
+            img = get_image(f'graphics/npc/enemy/enemy{i}.png', (100, 100))
+            if img:
+                self.enemy_frames.append(img)
+
+        # Animation state
+        self.anim_timer = 0
+        self.current_frame = 0
+
+    def show(self, reason):
+        """Show game over screen with given reason."""
+        self.is_showing = True
+        self.death_reason = reason
+        self.cooldown = 60  # 1 second delay before allowing restart
+        self.anim_timer = 0
+
+    def update(self, keys):
+        """Update game over screen. Returns 'restart' if player wants to restart."""
+        if not self.is_showing:
+            return None
+
+        self.anim_timer += 1
+
+        # Animate enemy (every 10 frames)
+        if self.anim_timer % 10 == 0 and self.enemy_frames:
+            self.current_frame = (self.current_frame + 1) % len(self.enemy_frames)
+
+        # Cooldown before allowing restart
+        if self.cooldown > 0:
+            self.cooldown -= 1
+            return None
+
+        # Check for restart input
+        if keys[pygame.K_SPACE] or keys[pygame.K_f]:
+            self.is_showing = False
+            self.death_reason = ""
+            return "restart"
+
+        return None
+
+    def draw(self, screen):
+        """Draw the game over screen."""
+        if not self.is_showing:
+            return
+
+        # Dark overlay
+        overlay = pygame.Surface((self.screen_width, self.screen_height), pygame.SRCALPHA)
+        overlay.fill((0, 0, 0, 180))
+        screen.blit(overlay, (0, 0))
+
+        center_x = self.screen_width // 2
+        center_y = self.screen_height // 2
+
+        # "GAME OVER" title
+        title_surface = self.title_font.render("GAME OVER", True, (255, 80, 80))
+        title_rect = title_surface.get_rect(centerx=center_x, centery=center_y - 80)
+        screen.blit(title_surface, title_rect)
+
+        # Death reason
+        reason_surface = self.reason_font.render(self.death_reason, True, (220, 220, 220))
+        reason_rect = reason_surface.get_rect(centerx=center_x, centery=center_y - 30)
+        screen.blit(reason_surface, reason_rect)
+
+        # Draw graphic based on death type
+        if "asleep" in self.death_reason.lower():
+            self._draw_zzz_animation(screen, center_x, center_y + 30)
+        else:
+            # Enemy graphic with animation and background
+            if self.enemy_frames:
+                # Light background circle so enemy is visible
+                pygame.draw.circle(screen, (60, 50, 70), (center_x, center_y + 40), 60)
+                pygame.draw.circle(screen, (80, 70, 90), (center_x, center_y + 40), 55)
+
+                # Draw animated enemy
+                enemy_img = self.enemy_frames[self.current_frame]
+                img_rect = enemy_img.get_rect(centerx=center_x, centery=center_y + 40)
+                screen.blit(enemy_img, img_rect)
+
+        # Restart hint
+        if self.cooldown <= 0:
+            hint_surface = self.hint_font.render("[SPACE] Try Again", True, (200, 180, 100))
+        else:
+            hint_surface = self.hint_font.render("...", True, (150, 150, 150))
+
+        hint_rect = hint_surface.get_rect(centerx=center_x, centery=center_y + 120)
+        screen.blit(hint_surface, hint_rect)
+
+    def _draw_zzz_animation(self, screen, center_x, center_y):
+        """Draw floating ZZZ animation."""
+        for i, char in enumerate("ZZZ"):
+            # Each Z floats up and down with offset timing
+            offset = (self.anim_timer + i * 20) % 60
+            float_y = abs(offset - 30) / 30 * 10
+
+            x = center_x - 40 + i * 30
+            y = center_y - float_y + i * 10
+
+            # Shadow
+            shadow = self.zzz_font.render(char, True, (50, 50, 80))
+            screen.blit(shadow, (x + 2, y + 2))
+
+            # Letter
+            letter = self.zzz_font.render(char, True, (150, 150, 255))
+            screen.blit(letter, (x, y))

--- a/src/world/background.py
+++ b/src/world/background.py
@@ -382,7 +382,7 @@ class Background:
                 pos = (x - camera_offset[0], y - camera_offset[1])
                 screen.blit(self.leaves_animation[self.leaves_frame], pos)
 
-    def draw(self, screen, camera_offset, player, cabin=None, enemy_manager=None):
+    def draw(self, screen, camera_offset, player, cabin=None, enemy_manager=None, is_brewing=False, brew_progress=0):
         """Draw all background layers."""
         self.draw_base_map(screen, camera_offset)
         # Cabin floor (under player)
@@ -395,6 +395,6 @@ class Background:
         self.draw_trees(screen, camera_offset)
         # Cabin walls/roof/furniture (over player when inside)
         if cabin:
-            cabin.draw_upper(screen, camera_offset, self.cat_images)
+            cabin.draw_upper(screen, camera_offset, self.cat_images, is_brewing, brew_progress)
         self.draw_cats(screen, camera_offset)
         self.draw_collectibles(screen, camera_offset)

--- a/src/world/cabin.py
+++ b/src/world/cabin.py
@@ -1,4 +1,5 @@
 import pygame
+import random
 
 TILE_SIZE = 64
 
@@ -61,19 +62,37 @@ def create_cabin_tiles():
     pygame.draw.rect(bed, (120, 90, 70), (48, 16, TILE_SIZE * 2 - 56, TILE_SIZE - 30))
     tiles['bed'] = bed
 
-    # Coffee machine - rustic kettle/pot style
+    # Coffee machine - espresso machine style
     coffee = pygame.Surface((TILE_SIZE, TILE_SIZE), pygame.SRCALPHA)
     coffee.fill((0, 0, 0, 0))
-    # Stolik
-    pygame.draw.rect(coffee, (100, 70, 45), (8, 40, 48, 24))
-    # Kociołek/czajnik
-    pygame.draw.ellipse(coffee, (60, 55, 50), (16, 20, 32, 28))
-    pygame.draw.ellipse(coffee, (50, 45, 42), (20, 24, 24, 20))
-    # Uchwyt
-    pygame.draw.arc(coffee, (70, 60, 55), (38, 22, 16, 20), -1.5, 1.5, 3)
-    # Para
-    pygame.draw.line(coffee, (200, 200, 200), (28, 18), (26, 10), 2)
-    pygame.draw.line(coffee, (200, 200, 200), (36, 18), (38, 8), 2)
+
+    # Table/counter
+    pygame.draw.rect(coffee, (100, 70, 45), (4, 48, 56, 16))
+    pygame.draw.rect(coffee, (80, 55, 35), (4, 48, 56, 4))
+
+    # Machine body (centered)
+    pygame.draw.rect(coffee, (70, 65, 60), (16, 12, 32, 38))  # Main body
+    pygame.draw.rect(coffee, (85, 80, 75), (18, 14, 28, 34))  # Front panel
+    pygame.draw.rect(coffee, (50, 45, 40), (16, 8, 32, 6))    # Top
+
+    # Drip tray area
+    pygame.draw.rect(coffee, (40, 35, 30), (20, 42, 24, 8))
+
+    # Cup slot (dark opening)
+    pygame.draw.rect(coffee, (30, 25, 20), (24, 30, 16, 14))
+
+    # Portafilter handle
+    pygame.draw.rect(coffee, (60, 50, 40), (22, 26, 20, 4))
+    pygame.draw.circle(coffee, (50, 40, 30), (42, 28), 4)
+
+    # Buttons/controls
+    pygame.draw.circle(coffee, (180, 50, 50), (24, 18), 3)  # Red button
+    pygame.draw.circle(coffee, (50, 150, 50), (34, 18), 3)  # Green button
+
+    # Steam (subtle)
+    pygame.draw.line(coffee, (200, 200, 200), (28, 8), (26, 2), 2)
+    pygame.draw.line(coffee, (200, 200, 200), (36, 8), (38, 2), 2)
+
     tiles['coffee'] = coffee
 
     # Cat bed/cushion - wygodne legowisko dla kotka
@@ -123,13 +142,13 @@ class Cabin:
         self.bed_pos = (1, 1)      # Top-left inside (2 tiles wide)
         self.coffee_pos = (8, 1)   # Top-right inside
 
-        # Pozycje legowisk dla kotków (5 legowisk pod górną ścianą)
+        # Cat bed positions (5 beds along left wall)
         self.cat_bed_positions = [
-            (3, 2),   # Pod ścianą - lewo
-            (4, 2),   # Pod ścianą - środek-lewo
-            (5, 2),   # Pod ścianą - środek
-            (6, 2),   # Pod ścianą - środek-prawo
-            (7, 2),   # Pod ścianą - prawo
+            (1, 3),   # Left wall - top
+            (1, 4),   # Left wall - upper-mid
+            (1, 5),   # Left wall - middle
+            (1, 6),   # Left wall - lower-mid
+            (1, 7),   # Left wall - bottom
         ]
 
         # Build collision rects for walls AND furniture
@@ -223,6 +242,21 @@ class Cabin:
         """Return count of stored cats."""
         return len(self.stored_cats)
 
+    def get_coffee_machine_world_pos(self):
+        """Get coffee machine position in world pixels."""
+        coffee_x = (self.x + self.coffee_pos[0]) * self.tile_size + self.tile_size // 2
+        coffee_y = (self.y + self.coffee_pos[1]) * self.tile_size + self.tile_size // 2
+        return (coffee_x, coffee_y)
+
+    def is_near_coffee_machine(self, player_rect):
+        """Check if player is near the coffee machine."""
+        coffee_pos = self.get_coffee_machine_world_pos()
+        player_center = player_rect.center
+        dx = coffee_pos[0] - player_center[0]
+        dy = coffee_pos[1] - player_center[1]
+        distance = (dx * dx + dy * dy) ** 0.5
+        return distance < 80  # 80px proximity radius
+
     def draw_floor(self, screen, camera_offset):
         """Draw cabin floor layer (under player)."""
         for row_idx, row in enumerate(self.layout):
@@ -235,7 +269,7 @@ class Cabin:
                 if tile_type == 0 or tile_type == 2:  # Floor or Door area
                     screen.blit(self.tiles['floor'], (screen_x, screen_y))
 
-    def draw_upper(self, screen, camera_offset, cat_images=None):
+    def draw_upper(self, screen, camera_offset, cat_images=None, is_brewing=False, brew_progress=0):
         """Draw cabin walls, roof, and furniture (over player)."""
         for row_idx, row in enumerate(self.layout):
             for col_idx, tile_type in enumerate(row):
@@ -258,7 +292,13 @@ class Cabin:
         # Coffee kettle
         coffee_world_x = (self.x + self.coffee_pos[0]) * self.tile_size
         coffee_world_y = (self.y + self.coffee_pos[1]) * self.tile_size
-        screen.blit(self.tiles['coffee'], (coffee_world_x - camera_offset[0], coffee_world_y - camera_offset[1]))
+        coffee_screen_x = coffee_world_x - camera_offset[0]
+        coffee_screen_y = coffee_world_y - camera_offset[1]
+        screen.blit(self.tiles['coffee'], (coffee_screen_x, coffee_screen_y))
+
+        # Draw brewing animation
+        if is_brewing:
+            self._draw_brewing_animation(screen, coffee_screen_x, coffee_screen_y, brew_progress)
 
         # Draw cat beds (legowiska pod ścianą)
         for i, (bx, by) in enumerate(self.cat_bed_positions):
@@ -273,3 +313,38 @@ class Cabin:
                     cat_x = bed_world_x + 8
                     cat_y = bed_world_y - 12
                     screen.blit(cat_images[cat_index], (cat_x - camera_offset[0], cat_y - camera_offset[1]))
+
+    def _draw_brewing_animation(self, screen, coffee_x, coffee_y, progress):
+        """Draw steam and progress bar for brewing coffee."""
+        # Steam particles (more intense during brewing)
+        steam_center_x = coffee_x + 32
+        steam_base_y = coffee_y + 18
+
+        for i in range(5):
+            # Random offset for each steam particle
+            x_offset = random.randint(-8, 8)
+            y_offset = random.randint(0, 20)
+
+            # Particle size varies
+            size = random.randint(2, 4)
+
+            # Draw steam particle
+            pygame.draw.circle(screen, (220, 220, 220),
+                             (steam_center_x + x_offset, steam_base_y - y_offset), size)
+
+        # Progress bar above coffee machine
+        bar_width = 50
+        bar_height = 8
+        bar_x = coffee_x + 7
+        bar_y = coffee_y - 15
+
+        # Background
+        pygame.draw.rect(screen, (40, 40, 40), (bar_x, bar_y, bar_width, bar_height), border_radius=3)
+
+        # Fill (brown coffee color)
+        fill_width = int(bar_width * progress)
+        if fill_width > 0:
+            pygame.draw.rect(screen, (139, 90, 43), (bar_x, bar_y, fill_width, bar_height), border_radius=3)
+
+        # Border
+        pygame.draw.rect(screen, (100, 80, 60), (bar_x, bar_y, bar_width, bar_height), 2, border_radius=3)


### PR DESCRIPTION
- Add coffee machine in cabin with brewing animation (3s)
- Add fatigue/energy system that depletes over ~3 minutes
- Player slows down when energy drops below 30%
- Game over screen when energy reaches 0 or enemy catches player
- UI: energy bar and coffee cup in bottom-left panel
- UI: kittens/collectibles counters with labels at top-left
- Move cat beds to left wall for coffee machine access
- Keys: [C] brew coffee, [V] drink coffee, [SPACE] restart

Closes #6 
